### PR TITLE
Fixing issue #11

### DIFF
--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -132,7 +132,6 @@ final class TriptychView: UIView {
         for view in views.array {
             if let webview = (view as? WebView) {
                 webview.removeMessageHandlers()
-                webview.scrollView.delegate = nil
             }
         }
     }
@@ -252,7 +251,6 @@ final class TriptychView: UIView {
         scrollView.subviews.forEach({
             if let webview = ($0 as? WebView) {
                 webview.removeMessageHandlers()
-                webview.scrollView.delegate = nil
             }
             $0.removeFromSuperview()
         })
@@ -261,7 +259,6 @@ final class TriptychView: UIView {
             viewArray.forEach({
                 if let webview = ($0 as? WebView) {
                     webview.addMessageHandlers()
-                    webview.scrollView.delegate = webview
                 }
                 self.scrollView.addSubview($0)
             })

--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -131,8 +131,8 @@ final class TriptychView: UIView {
         }
         for view in views.array {
             if let webview = (view as? WebView) {
-                webview.scrollView.delegate = nil
                 webview.removeMessageHandlers()
+                webview.scrollView.delegate = nil
             }
         }
     }
@@ -162,22 +162,6 @@ final class TriptychView: UIView {
 
         let offset = min(1, index)
         scrollView.contentOffset.x = size.width * CGFloat(offset)
-    }
-
-    fileprivate func updateScrollViewDelegates(setToNil: Bool) {
-        guard let views = self.views else {
-            return
-        }
-        for (_, view) in views.array.enumerated() {
-            if let webView = view as? WebView {
-                if setToNil {
-                    webView.scrollView.delegate = nil
-                }
-                else {
-                    webView.scrollView.delegate = webView
-                }
-            }
-        }
     }
 
     fileprivate func updateViews(previousIndex: Int? = nil) {
@@ -223,8 +207,6 @@ final class TriptychView: UIView {
             return delegate.triptychView(self, viewForIndex: index, location: location)
         }
 
-        updateScrollViewDelegates(setToNil: true)
-
         switch viewCount {
         case 1:
             assert(index == 0)
@@ -262,7 +244,6 @@ final class TriptychView: UIView {
             }
         }
 
-        updateScrollViewDelegates(setToNil: false)
         syncSubviews()
         setNeedsLayout()
     }
@@ -271,6 +252,7 @@ final class TriptychView: UIView {
         scrollView.subviews.forEach({
             if let webview = ($0 as? WebView) {
                 webview.removeMessageHandlers()
+                webview.scrollView.delegate = nil
             }
             $0.removeFromSuperview()
         })
@@ -279,6 +261,7 @@ final class TriptychView: UIView {
             viewArray.forEach({
                 if let webview = ($0 as? WebView) {
                     webview.addMessageHandlers()
+                    webview.scrollView.delegate = webview
                 }
                 self.scrollView.addSubview($0)
             })

--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -131,6 +131,7 @@ final class TriptychView: UIView {
         }
         for view in views.array {
             if let webview = (view as? WebView) {
+                webview.scrollView.delegate = nil
                 webview.removeMessageHandlers()
             }
         }
@@ -161,6 +162,22 @@ final class TriptychView: UIView {
 
         let offset = min(1, index)
         scrollView.contentOffset.x = size.width * CGFloat(offset)
+    }
+
+    fileprivate func updateScrollViewDelegates(setToNil: Bool) {
+        guard let views = self.views else {
+            return
+        }
+        for (_, view) in views.array.enumerated() {
+            if let webView = view as? WebView {
+                if setToNil {
+                    webView.scrollView.delegate = nil
+                }
+                else {
+                    webView.scrollView.delegate = webView
+                }
+            }
+        }
     }
 
     fileprivate func updateViews(previousIndex: Int? = nil) {
@@ -206,6 +223,8 @@ final class TriptychView: UIView {
             return delegate.triptychView(self, viewForIndex: index, location: location)
         }
 
+        updateScrollViewDelegates(setToNil: true)
+
         switch viewCount {
         case 1:
             assert(index == 0)
@@ -243,6 +262,7 @@ final class TriptychView: UIView {
             }
         }
 
+        updateScrollViewDelegates(setToNil: false)
         syncSubviews()
         setNeedsLayout()
     }

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -79,6 +79,16 @@ final class WebView: WKWebView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func didMoveToSuperview() {
+        // Fixing an iOS 9 bug by explicitly clearing scrollView.delegate before deinitialization
+        if superview == nil {
+            scrollView.delegate = nil
+        }
+        else {
+            scrollView.delegate = self
+        }
+    }
 }
 
 extension WebView {


### PR DESCRIPTION
Fixing issue 11 (https://github.com/readium/r2-testapp-swift/issues/11)

The issue is caused by a WKWebView bug where it tries to use scrollView.delegate while being deallocated. The only fix is to set scrollView.delegate to nil before deallocation happens (doing it in WebView.deinit is too late and doesn't work). This means we have to manually keep track of WebViews and clear their scrollView.delegate before automatic deallocation happens.

The current code heavily relies on implicit deallocation and would need to be extensively refactored to actually track which views get deallocated. Instead, the fix simply sets the delegates of all views to nil before any updates to the views array, and restores them afterwards.