### PR TITLE
Fix a crash issue for over-released

### DIFF
--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -253,7 +253,6 @@ final class TriptychView: UIView {
                 views = Views.two(firstView: firstView, secondView: secondView)
             }
         default:
-            let currentView = viewForIndex(index, location: leading)
             if index == 0 {
                 self.views = Views.many(
                     currentView: viewForIndex(index, location: leading),
@@ -266,7 +265,7 @@ final class TriptychView: UIView {
                         viewForIndex(index - 1, location: leading)))
             } else {
                 views = Views.many(
-                    currentView: currentView,
+                    currentView: viewForIndex(index, location: leading),
                     otherViews: Disjunction.both(
                         first: viewForIndex(index - 1, location: trailing),
                         second: viewForIndex(index + 1, location: leading)))


### PR DESCRIPTION
Fix https://github.com/readium/r2-testapp-swift/issues/186

This crash will happen when I am using iOS simulator. I didn't see that on device. 
It will crash by calling `removeObserver` in the `deinit` method.
  
 ```
 deinit {
        scrollView.removeObserver(self, forKeyPath: "contentSize", context: nil)
}
```
https://opensource.apple.com/source/objc4/objc4-646/runtime/objc-weak.mm.auto.html
`Cannot form weak reference to instance (0x7f9d6c8a6200) of class R2Navigator.WebView. It is possible that this object was over-released, or is in the process of deallocation.`

But how does it happen?  With Apple' source code above, we know this error will be triggered by accessing weak reference of self during `deallocating`.
```
if (deallocating) {
        _objc_fatal("Cannot form weak reference to instance (%p) of "
                    "class %s. It is possible that this object was "
                    "over-released, or is in the process of deallocation.",
                    (void*)referent, object_getClassName((id)referent));
}
```
But I didn't see anything using weak reference in the Swift code. I guess Apple made some weak reference inside the function of `scrollView.removeObserver`. That's one of the possible reason.
```
 deinit {
        scrollView.removeObserver(self, forKeyPath: "contentSize", context: nil)
}
```