### PR TITLE
Bugs and various UX improvements

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "BookBeat/r2-shared-swift" "54bea7b9da2980da197b1b9208a0ef2f7c46c606"
-github "Hearst-DD/ObjectMapper" "3.3.0"
+github "Hearst-DD/ObjectMapper" "2.2.0"
+github "Readium/r2-shared-swift" "3dd222c34fcf658afd6bc4fd3e06218d773421bb"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Hearst-DD/ObjectMapper" "2.2.0"
-github "Readium/r2-shared-swift" "07f5fe26381e0980925f7a16e8c05a1c7455ea45"
+github "BookBeat/r2-shared-swift" "54bea7b9da2980da197b1b9208a0ef2f7c46c606"
+github "Hearst-DD/ObjectMapper" "3.3.0"

--- a/r2-navigator-swift.xcodeproj/project.pbxproj
+++ b/r2-navigator-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D3A2F56218C85A100108B31 /* PageTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3A2F55218C85A100108B31 /* PageTransition.swift */; };
 		F341C2711F506ED5005E6758 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F341C2701F506ED5005E6758 /* UserSettings.swift */; };
 		F3E7D3D41F4D83B000DF166D /* r2-navigator-swift.h in Headers */ = {isa = PBXBuildFile; fileRef = F3E7D3C61F4D83B000DF166D /* r2-navigator-swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3E7D3DE1F4D845B00DF166D /* BinaryLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3E7D3DD1F4D845B00DF166D /* BinaryLocation.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1D3A2F55218C85A100108B31 /* PageTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTransition.swift; sourceTree = "<group>"; };
 		F341C2701F506ED5005E6758 /* UserSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		F3B2C86C1F603E79007601E4 /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		F3E7D3C31F4D83B000DF166D /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,6 +105,7 @@
 				F3E7D3DD1F4D845B00DF166D /* BinaryLocation.swift */,
 				F3E7D3DF1F4D847E00DF166D /* Disjunction.swift */,
 				F341C2701F506ED5005E6758 /* UserSettings.swift */,
+				1D3A2F55218C85A100108B31 /* PageTransition.swift */,
 			);
 			name = EPUB;
 			sourceTree = "<group>";
@@ -203,6 +206,7 @@
 				F341C2711F506ED5005E6758 /* UserSettings.swift in Sources */,
 				F3E7D3DE1F4D845B00DF166D /* BinaryLocation.swift in Sources */,
 				F3E7D3E41F4D84DC00DF166D /* TriptychView.swift in Sources */,
+				1D3A2F56218C85A100108B31 /* PageTransition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -21,6 +21,7 @@ public protocol NavigatorDelegate: class {
     func didChangedDocumentPage(currentDocumentIndex: Int)
     func didChangedPaginatedDocumentPage(currentPage: Int, documentTotalPage: Int)
     func didNavigateViaInternalLinkTap(to documentIndex: Int)
+    func didTapExternalUrl(_ : URL)
 }
 
 public extension NavigatorDelegate {
@@ -175,6 +176,10 @@ extension NavigatorViewController {
 }
 
 extension NavigatorViewController: ViewDelegate {
+    
+    func handleTapOnLink(with url: URL) {
+        delegate?.didTapExternalUrl(url)
+    }
     
     func handleTapOnInternalLink(with href: String) {
         guard let index = displaySpineItem(with: href) else { return }

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -71,6 +71,8 @@ open class NavigatorViewController: UIViewController {
     open override func viewDidLoad() {
         super.viewDidLoad()
         delegatee.parent = self
+        view.backgroundColor = .clear
+        triptychView.backgroundColor = .clear
         triptychView.delegate = delegatee
         triptychView.frame = view.bounds
         triptychView.autoresizingMask = [.flexibleHeight, .flexibleWidth]

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -20,7 +20,7 @@ public protocol NavigatorDelegate: class {
     /// It changes when html file resource changed
     func didChangedDocumentPage(currentDocumentIndex: Int)
     func didChangedPaginatedDocumentPage(currentPage: Int, documentTotalPage: Int)
-    func didNavigateViaInternalLinkTap(to link: Link)
+    func didNavigateViaInternalLinkTap(to documentIndex: Int)
 }
 
 public extension NavigatorDelegate {
@@ -133,14 +133,15 @@ extension NavigatorViewController {
     /// Load resource with the corresponding href.
     ///
     /// - Parameter href: The href of the resource to load. Can contain a tag id.
-    public func displaySpineItem(with href: String) {
+    /// - Return: The document index for the link
+    public func displaySpineItem(with href: String) -> Int? {
         // remove id if any
         let components = href.components(separatedBy: "#")
         guard let href = components.first else {
-            return
+            return nil
         }
         guard let index = publication.spine.index(where: { $0.href?.contains(href) ?? false }) else {
-            return
+            return nil
         }
         // If any id found, set the scroll position to it, else to the
         // beggining of the document.
@@ -150,6 +151,7 @@ extension NavigatorViewController {
         fadeTriptychView {
             self.triptychView.moveTo(index: index, id: id)
         }
+        return index
     }
 
     public func getSpine() -> [Link] {
@@ -175,17 +177,8 @@ extension NavigatorViewController {
 extension NavigatorViewController: ViewDelegate {
     
     func handleTapOnInternalLink(with href: String) {
-        displaySpineItem(with: href)
-        
-        //I'd like to refactor the displaySpineItem to use a link instead of a string href, but I don't want to restructure the navigator too much. This therefore more or less copied from the displaySpineItem-function.
-        let components = href.components(separatedBy: "#")
-        guard let href = components.first else {
-            return
-        }
-        guard let link = publication.spine.first(where: { $0.href?.contains(href) ?? false }) else {
-            return
-        }
-        delegate?.didNavigateViaInternalLinkTap(to: link)
+        guard let index = displaySpineItem(with: href) else { return }
+        delegate?.didNavigateViaInternalLinkTap(to: index)
     }
     
     func documentPageDidChanged(webview: WebView, currentPage: Int, totalPage: Int) {

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -90,6 +90,7 @@ open class NavigatorViewController: UIViewController {
     }
 
     open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         // Save the currently opened document index and progression.
         if navigationController == nil {
             let progression = triptychView.getCurrentDocumentProgression()
@@ -277,6 +278,10 @@ extension Delegatee: TriptychViewDelegate {
 
 
 extension NavigatorViewController {
+    
+    public var contentView: UIView {
+        return triptychView
+    }
     
     func fadeTriptychView(becameHidden: @escaping () -> ()) {
         fadeTriptychView(alpha: 0) {

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -256,11 +256,11 @@ extension Delegatee: TriptychViewDelegate {
 extension NavigatorViewController {
     
     func fadeInOutTriptychView(becameHidden: @escaping () -> ()) {
-        UIView.animate(withDuration: 0.3, animations: {
+        UIView.animate(withDuration: 0.15, animations: {
             self.triptychView.alpha = 0
         }) { (_) in
             becameHidden()
-            UIView.animate(withDuration: 0.3, animations: {
+            UIView.animate(withDuration: 0.15, animations: {
                 self.triptychView.alpha = 1
             })
         }

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -20,6 +20,7 @@ public protocol NavigatorDelegate: class {
     /// It changes when html file resource changed
     func didChangedDocumentPage(currentDocumentIndex: Int)
     func didChangedPaginatedDocumentPage(currentPage: Int, documentTotalPage: Int)
+    func didNavigateViaInternalLinkTap(to link: Link)
 }
 
 public extension NavigatorDelegate {
@@ -172,6 +173,21 @@ extension NavigatorViewController {
 }
 
 extension NavigatorViewController: ViewDelegate {
+    
+    func handleTapOnInternalLink(with href: String) {
+        displaySpineItem(with: href)
+        
+        //I'd like to refactor the displaySpineItem to use a link instead of a string href, but I don't want to restructure the navigator too much. This therefore more or less copied from the displaySpineItem-function.
+        let components = href.components(separatedBy: "#")
+        guard let href = components.first else {
+            return
+        }
+        guard let link = publication.spine.first(where: { $0.href?.contains(href) ?? false }) else {
+            return
+        }
+        delegate?.didNavigateViaInternalLinkTap(to: link)
+    }
+    
     func documentPageDidChanged(webview: WebView, currentPage: Int, totalPage: Int) {
         if triptychView.currentView == webview {
             delegate?.didChangedPaginatedDocumentPage(currentPage: currentPage, documentTotalPage: totalPage)

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -116,6 +116,7 @@ extension NavigatorViewController {
     ///
     /// - Parameter index: The index of the spine item to display.
     public func displaySpineItem(at index: Int, progression: Double) {
+        self.initialProgression = progression //This is so the webview will move to it's correct progression
         displaySpineItem(at: index)
         if let webView = triptychView.currentView as? WebView {
             webView.scrollAt(position: progression)

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -116,10 +116,16 @@ extension NavigatorViewController {
     ///
     /// - Parameter index: The index of the spine item to display.
     public func displaySpineItem(at index: Int, progression: Double) {
-        self.initialProgression = progression //This is so the webview will move to it's correct progression
-        displaySpineItem(at: index)
-        if let webView = triptychView.currentView as? WebView {
-            webView.scrollAt(position: progression)
+        guard publication.spine.indices.contains(index) else {
+            return
+        }
+        
+        fadeInOutTriptychView {
+            self.initialProgression = progression //This is so the webview will move to it's correct progression if it's not loaded into the triptych view
+            self.triptychView.moveTo(index: index)
+            if let webView = self.triptychView.currentView as? WebView {
+                webView.scrollAt(position: progression)
+            }
         }
     }
     

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -135,7 +135,7 @@ extension NavigatorViewController {
     /// Load resource with the corresponding href.
     ///
     /// - Parameter href: The href of the resource to load. Can contain a tag id.
-    /// - Return: The document index for the link
+    /// - Returns: The spine index for the link
     public func displaySpineItem(with href: String) -> Int? {
         // remove id if any
         let components = href.components(separatedBy: "#")

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -107,7 +107,7 @@ extension NavigatorViewController {
         guard publication.spine.indices.contains(index) else {
             return
         }
-        fadeInOutTriptychView {
+        fadeTriptychView {
             self.triptychView.moveTo(index: index)
         }
     }
@@ -120,7 +120,7 @@ extension NavigatorViewController {
             return
         }
         
-        fadeInOutTriptychView {
+        fadeTriptychViewDelayed {
             self.initialProgression = progression //This is so the webview will move to it's correct progression if it's not loaded into the triptych view
             self.triptychView.moveTo(index: index)
             if let webView = self.triptychView.currentView as? WebView {
@@ -146,7 +146,7 @@ extension NavigatorViewController {
         let id = (components.count > 1 ? components.last : "")
 
         // Jumping set to true to avoid clamping.
-        fadeInOutTriptychView {
+        fadeTriptychView {
             self.triptychView.moveTo(index: index, id: id)
         }
     }
@@ -264,14 +264,30 @@ extension Delegatee: TriptychViewDelegate {
 
 extension NavigatorViewController {
     
-    func fadeInOutTriptychView(becameHidden: @escaping () -> ()) {
-        UIView.animate(withDuration: 0.15, animations: {
-            self.triptychView.alpha = 0
-        }) { (_) in
+    func fadeTriptychView(becameHidden: @escaping () -> ()) {
+        fadeTriptychView(alpha: 0) {
             becameHidden()
-            UIView.animate(withDuration: 0.15, animations: {
-                self.triptychView.alpha = 1
+            self.fadeTriptychView(alpha: 1, completion: { })
+        }
+    }
+    
+    /*
+     This is used when we want to jump to a document with proression. The rendering is sometimes very slow in this case so we have a generous delay before we show the view again.
+     */
+    func fadeTriptychViewDelayed(becameHidden: @escaping () -> ()) {
+        fadeTriptychView(alpha: 0) {
+            becameHidden()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+                self.fadeTriptychView(alpha: 1, completion: { })
             })
+        }
+    }
+    
+    private func fadeTriptychView(alpha: CGFloat, completion: @escaping () -> ()) {
+        UIView.animate(withDuration: 0.15, animations: {
+            self.triptychView.alpha = alpha
+        }) { _ in
+            completion()
         }
     }
 }

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -105,7 +105,9 @@ extension NavigatorViewController {
         guard publication.spine.indices.contains(index) else {
             return
         }
-        triptychView.moveTo(index: index)
+        fadeInOutTriptychView {
+            self.triptychView.moveTo(index: index)
+        }
     }
     
     /// Display the spine item at `index` with scroll `progression`
@@ -135,7 +137,9 @@ extension NavigatorViewController {
         let id = (components.count > 1 ? components.last : "")
 
         // Jumping set to true to avoid clamping.
-        triptychView.moveTo(index: index, id: id)
+        fadeInOutTriptychView {
+            self.triptychView.moveTo(index: index, id: id)
+        }
     }
 
     public func getSpine() -> [Link] {
@@ -168,13 +172,13 @@ extension NavigatorViewController: ViewDelegate {
     /// Display next spine item (spine item).
     public func displayRightDocument() {
         let delta = triptychView.direction == .rtl ? -1:1
-        displaySpineItem(at: triptychView.index + delta)
+        self.displaySpineItem(at: self.triptychView.index + delta)
     }
 
     /// Display previous document (spine item).
     public func displayLeftDocument() {
         let delta = triptychView.direction == .rtl ? -1:1
-        displaySpineItem(at: triptychView.index - delta)
+        self.displaySpineItem(at: self.triptychView.index - delta)
     }
 
     /// Returns the currently presented Publication's identifier.
@@ -244,6 +248,21 @@ extension Delegatee: TriptychViewDelegate {
             if let pages = cw.totalPages {
                 parent.delegate?.didChangedPaginatedDocumentPage(currentPage: cw.currentPage(), documentTotalPage: pages)
             }
+        }
+    }
+}
+
+
+extension NavigatorViewController {
+    
+    func fadeInOutTriptychView(becameHidden: @escaping () -> ()) {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.triptychView.alpha = 0
+        }) { (_) in
+            becameHidden()
+            UIView.animate(withDuration: 0.3, animations: {
+                self.triptychView.alpha = 1
+            })
         }
     }
 }

--- a/r2-navigator-swift/PageTransition.swift
+++ b/r2-navigator-swift/PageTransition.swift
@@ -1,0 +1,17 @@
+//
+//  PageTransition.swift
+//  r2-navigator-swift
+//
+//  Created by Jonas Ullström on 2018-11-02.
+//
+//  Copyright 2018 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by a BSD-style license which is detailed
+//  in the LICENSE file present in the project repository where this source code is maintained.
+//
+
+import Foundation
+
+public enum PageTransition {
+    case none
+    case animated
+}

--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -279,10 +279,8 @@ final class TriptychView: UIView {
     }
 
     private func syncSubviews() {
+        let webViewsBefore = scrollView.subviews.compactMap { $0 as? WebView }
         scrollView.subviews.forEach({
-            if let webview = ($0 as? WebView) {
-                webview.removeMessageHandlers()
-            }
             $0.removeFromSuperview()
         })
 
@@ -293,6 +291,10 @@ final class TriptychView: UIView {
                 }
                 self.scrollView.addSubview($0)
             })
+        }
+        
+        webViewsBefore.forEach {
+            if $0.superview == nil { $0.removeMessageHandlers() }
         }
     }
 }

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -20,7 +20,7 @@ protocol ViewDelegate: class {
     func handleCenterTap()
     func publicationIdentifier() -> String?
     func publicationBaseUrl() -> URL?
-    func displaySpineItem(with href: String)
+    func handleTapOnInternalLink(with href: String)
     func documentPageDidChanged(webview: WebView, currentPage: Int ,totalPage: Int)
 }
 
@@ -324,7 +324,7 @@ extension WebView: WKNavigationDelegate {
                     // Internal link.
                     let href = url.absoluteString.replacingOccurrences(of: baseUrlString, with: "")
 
-                    viewDelegate?.displaySpineItem(with: href)
+                    viewDelegate?.handleTapOnInternalLink(with: href)
                 } else if url.absoluteString.contains("http") { // TEMPORARY, better checks coming.
                     // External Link.
                     let view = SFSafariViewController(url: url)

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -347,6 +347,10 @@ extension WebView: UIScrollViewDelegate {
         }
         return nil
     }
+    
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        scrollView.isUserInteractionEnabled = true
+    }
 }
 
 extension WebView: WKUIDelegate {
@@ -375,6 +379,8 @@ private extension UIScrollView {
     }
     
     private func moveHorizontalContent(with offsetX: CGFloat) {
+        isUserInteractionEnabled = false
+        
         var newOffset = contentOffset
         newOffset.x += offsetX
         let rounded = round(newOffset.x / offsetX) * offsetX

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -353,19 +353,18 @@ extension WebView: UIScrollViewDelegate {
 extension UIScrollView {
     
     func scrollToNextPage() {
-        //FIXME: Fix bug with getting stuck between two pages
-        var newOffset = contentOffset
-        let incr = bounds.size.width
-        newOffset.x += incr
-        let area = CGRect.init(origin: newOffset, size: bounds.size)
-        scrollRectToVisible(area, animated: true)
+        moveHorizontalContent(with: bounds.size.width)
     }
     
     func scrollToPreviousPage() {
-        //FIXME: Fix bug with getting stuck between two pages
+        moveHorizontalContent(with: -bounds.size.width)
+    }
+    
+    private func moveHorizontalContent(with offsetX: CGFloat) {
         var newOffset = contentOffset
-        let incr = bounds.size.width
-        newOffset.x -= incr
+        newOffset.x += offsetX
+        let rounded = round(newOffset.x / offsetX) * offsetX
+        newOffset.x = rounded
         let area = CGRect.init(origin: newOffset, size: bounds.size)
         scrollRectToVisible(area, animated: true)
     }

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -113,6 +113,7 @@ final class WebView: WKWebView {
         
         sizeObservation = scrollView.observe(\.contentSize, options: .new) { (thisScrollView, thisValue) in
             // update total pages
+            guard self.documentLoaded else { return }
             guard let newWidth = thisValue.newValue?.width else {return}
             let pageWidth = self.scrollView.frame.size.width
             if pageWidth == 0.0 {return} // Possible zero value


### PR DESCRIPTION
After discussing with hadrien on Slack, I've decided to make a PR for the current state of the Navigator we are using in our project. This PR is a mixture of bug fixes and some UX improvements.


This PR consists of the following features:

- Fading in the WebView after document load
- Fade animation when tap-navigating between two documents
- Native scroll animation when tap-navigating between two pages in a document


The bug fixes included are the following:

- Not always getting document load-callback from javascript due to removing and adding js-events
- Jump to document with progression for a document that is not loaded into the triptych view
- Prevent peek'n'pop for localhost-links


The refactoring that will result in change of behaviour:

- The WebView is not presenting a SFSafariViewController when tapping external links anymore, but instead passes this to its delegate
