### PR TITLE
Clamping bug when dragging forward and backwards in same swipe

### DIFF
--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -399,6 +399,14 @@ extension TriptychView: UIScrollViewDelegate {
             }
         }
     }
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        // Set the clamping to .none here to prevent the bug introduced by
+        // the workaround in scrollViewDidEndDecelerating where the
+        // scrollview contentOffset is animated.
+        // When animating the contentOffset, scrollViewDidScroll is called
+        // without calling scrollViewDidEndDecelerating afterwards.
+        clamping = .none
+    }
 
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
 

--- a/r2-navigator-swift/TriptychView.swift
+++ b/r2-navigator-swift/TriptychView.swift
@@ -399,12 +399,19 @@ extension TriptychView: UIScrollViewDelegate {
             }
         }
     }
+    
+    // Set the clamping to .none in scrollViewDidEndScrollingAnimation
+    // and scrollViewDidEndDragging with decelerate == false,
+    // to prevent the bug introduced by the workaround in
+    // scrollViewDidEndDecelerating where the scrollview contentOffset
+    // is animated. When animating the contentOffset, scrollViewDidScroll
+    // is called without calling scrollViewDidEndDecelerating afterwards.
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        // Set the clamping to .none here to prevent the bug introduced by
-        // the workaround in scrollViewDidEndDecelerating where the
-        // scrollview contentOffset is animated.
-        // When animating the contentOffset, scrollViewDidScroll is called
-        // without calling scrollViewDidEndDecelerating afterwards.
+        clamping = .none
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if decelerate { return }
         clamping = .none
     }
 


### PR DESCRIPTION
To reproduce the bug which this PR fixes:

- Open i.e. "Moby dick" in R2 Reader
- Go to About
- Start dragging to the next page, but cancel the drag by "dragging back again" or "slam" it back with a drag
- Now you cannot swipe to the previous page

**How to fix:**
This PR sets clamping to .none in scrollViewDidEndScrollingAnimation and scrollViewDidEndDragging (if decelerate is false).

This is to prevent the bug introduced by the workaround in scrollViewDidEndDecelerating where the scrollview contentOffset is animated.

When animating the contentOffset, scrollViewDidScroll is called without calling scrollViewDidEndDecelerating afterwards.