### PR TITLE
Fix bug with chapter change if swiping during a tap animation

### DIFF
--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -201,7 +201,7 @@ extension NavigatorViewController: ViewDelegate {
         triptychView.isUserInteractionEnabled = false
     }
     
-    func didAnimatePageChange() {
+    func didEndPageAnimation() {
         triptychView.isUserInteractionEnabled = true
     }
     

--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -197,6 +197,14 @@ extension NavigatorViewController {
 
 extension NavigatorViewController: ViewDelegate {
     
+    func willAnimatePageChange() {
+        triptychView.isUserInteractionEnabled = false
+    }
+    
+    func didAnimatePageChange() {
+        triptychView.isUserInteractionEnabled = true
+    }
+    
     func handleTapOnLink(with url: URL) {
         delegate?.didTapExternalUrl(url)
     }

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -14,6 +14,8 @@ import WebKit
 import R2Shared
 
 protocol ViewDelegate: class {
+    func willAnimatePageChange()
+    func didAnimatePageChange()
     func displayRightDocument()
     func displayLeftDocument()
     func handleCenterTap()
@@ -106,11 +108,13 @@ final class WebView: WKWebView {
             case .left:
                 let isAtFirstPageInDocument = scrollView.contentOffset.x == 0
                 if !isAtFirstPageInDocument {
+                    target.viewDelegate?.willAnimatePageChange()
                     return scrollView.scrollToPreviousPage()
                 }
             case .right:
                 let isAtLastPageInDocument = scrollView.contentOffset.x == scrollView.contentSize.width - scrollView.frame.size.width
                 if !isAtLastPageInDocument {
+                    target.viewDelegate?.willAnimatePageChange()
                     return scrollView.scrollToNextPage()
                 }
             }
@@ -380,6 +384,7 @@ extension WebView: UIScrollViewDelegate {
     
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         scrollView.isUserInteractionEnabled = true
+        viewDelegate?.didAnimatePageChange()
     }
 }
 

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -15,7 +15,7 @@ import R2Shared
 
 protocol ViewDelegate: class {
     func willAnimatePageChange()
-    func didAnimatePageChange()
+    func didEndPageAnimation()
     func displayRightDocument()
     func displayLeftDocument()
     func handleCenterTap()
@@ -384,7 +384,15 @@ extension WebView: UIScrollViewDelegate {
     
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         scrollView.isUserInteractionEnabled = true
-        viewDelegate?.didAnimatePageChange()
+        viewDelegate?.didEndPageAnimation()
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        viewDelegate?.didEndPageAnimation()
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        viewDelegate?.didEndPageAnimation()
     }
 }
 


### PR DESCRIPTION
This PR fixes this bug:
When animating a page change within a chapter, if the user swipes from the side during the animation, a chapter change is performed. This is due to how iOS delegates touch events when user interaction is disabled.