### PR TITLE
Add option to disable drag and drop on iPads

### DIFF
--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -58,14 +58,16 @@ open class NavigatorViewController: UIViewController {
     public weak var delegate: NavigatorDelegate?
 
     public let pageTransition: PageTransition
+    public let disableDragAndDrop: Bool
 
     /// - Parameters:
     ///   - publication: The publication.
     ///   - initialIndex: Inital index of -1 will open the publication's at the end.
-    public init(for publication: Publication, initialIndex: Int, initialProgression: Double?, pageTransition: PageTransition = .none) {
+    public init(for publication: Publication, initialIndex: Int, initialProgression: Double?, pageTransition: PageTransition = .none, disableDragAndDrop: Bool = false) {
         self.publication = publication
         self.initialProgression = initialProgression
         self.pageTransition = pageTransition
+        self.disableDragAndDrop = disableDragAndDrop
         userSettings = UserSettings()
         publication.userProperties.properties = userSettings.userProperties.properties
         delegatee = Delegatee()
@@ -252,7 +254,7 @@ extension Delegatee: TriptychViewDelegate {
     public func triptychView(_ view: TriptychView, viewForIndex index: Int,
                              location: BinaryLocation) -> UIView {
         
-        let webView = WebView(frame: view.bounds, initialLocation: location, pageTransition: parent.pageTransition)
+        let webView = WebView(frame: view.bounds, initialLocation: location, pageTransition: parent.pageTransition, disableDragAndDrop: parent.disableDragAndDrop)
         webView.direction = view.direction
         
         let link = parent.publication.spine[index]

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -120,11 +120,11 @@ final class WebView: WKWebView {
     
     var sizeObservation: NSKeyValueObservation?
 
-    init(frame: CGRect, initialLocation: BinaryLocation, pageTransition: PageTransition = .none) {
+    init(frame: CGRect, initialLocation: BinaryLocation, pageTransition: PageTransition = .none, disableDragAndDrop: Bool = false) {
         self.initialLocation = initialLocation
         self.pageTransition = pageTransition
         super.init(frame: frame, configuration: .init())
-
+        if disableDragAndDrop { disableDragAndDropInteraction() }
         isOpaque = false
         backgroundColor = UIColor.clear
         scrollView.backgroundColor = UIColor.clear
@@ -457,5 +457,13 @@ private extension WebView {
         view.startAnimating()
         activityIndicatorView = view
     }
+    
+    func disableDragAndDropInteraction() {
+        if #available(iOS 11.0, *) {
+            guard let webScrollView = subviews.compactMap( { $0 as? UIScrollView }).first,
+                let contentView = webScrollView.subviews.first(where: { $0.interactions.count > 1 }),
+                let dragInteraction = contentView.interactions.compactMap({ $0 as? UIDragInteraction }).first else { return }
+            contentView.removeInteraction(dragInteraction)
+        }
+    }
 }
-


### PR DESCRIPTION
This PR allows the navigator to disable drag and drop on iPads. 
 
This is to prevent users from having the ability to drag and drop images from the book to the images app on the iPad.

It is set to false by default so it does not change the current behaviour of the navigator. If it is set to true it only affects UIDragInteractions and cancels those so all other interaction woks as it did before.


