### PR TITLE
Display JS logs in the app, and log uncaught JS errors

### DIFF
--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -165,6 +165,32 @@ class EPUBSpreadView: UIView, Loggable {
     func evaluateScript(_ script: String, completion: ((Any?, Error?) -> Void)? = nil) {
         webView.evaluateJavaScript(script, completionHandler: completion)
     }
+    
+    /// Called from the JS code when logging a message.
+    private func didLog(_ body: Any) {
+        guard let body = body as? String else {
+            return
+        }
+        log(.debug, "JavaScript: \(body)")
+    }
+    
+    /// Called from the JS code when logging an error.
+    private func didLogError(_ body: Any) {
+        guard let error = body as? [String: Any],
+            var message = error["message"] as? String else
+        {
+            return
+        }
+        message = "JavaScript: \(message)"
+        
+        if let file = error["filename"] as? String, file != "/",
+            let line = error["line"] as? Int, line != 0
+        {
+            self.log(.error, message, file: file, line: line)
+        } else {
+            self.log(.error, message)
+        }
+    }
   
     /// Called from the JS code when a tap is detected.
     private func didTap(_ body: Any) {
@@ -313,6 +339,8 @@ class EPUBSpreadView: UIView, Loggable {
     
     /// To override in subclasses if needed.
     func registerJSMessages() {
+        registerJSMessage(named: "log") { [weak self] in self?.didLog($0) }
+        registerJSMessage(named: "logError") { [weak self] in self?.didLogError($0) }
         registerJSMessage(named: "tap") { [weak self] in self?.didTap($0) }
         registerJSMessage(named: "spreadLoaded") { [weak self] in self?.spreadDidLoad($0) }
         registerJSMessage(named: "selectionChanged") { [weak self] in self?.selectionDidChange($0) }

--- a/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
+++ b/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
@@ -3,6 +3,14 @@
 // WARNING: iOS 9 requires ES5
 
 var readium = (function() {
+    // Catch JS errors to log them in the app.
+    window.addEventListener("error", function(event) {
+        webkit.messageHandlers.logError.postMessage({
+            "message": event.message,
+            "filename": event.filename,
+            "line": event.lineno
+        });
+    }, false);
     
     // Notify native code that the page has loaded.
     window.addEventListener("load", function(){ // on page load


### PR DESCRIPTION
This is to help debug and notice JS errors without starting the Web Inspector. It can be used to debug publications as well.

<img width="906" alt="Screenshot 2020-04-15 at 16 43 08" src="https://user-images.githubusercontent.com/58686775/79351174-a74da080-7f38-11ea-8a6c-b784acb5b068.png">
