### PR TITLE
Fix various EPUB navigator issues

### DIFF
--- a/r2-navigator-swift.xcodeproj/project.pbxproj
+++ b/r2-navigator-swift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		035CE41724F7E2090062EE28 /* SwiftSoup.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 035CE41624F7E2090062EE28 /* SwiftSoup.framework */; };
 		03C3CC68222DBD8600A01731 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03C3CC67222DBD8600A01731 /* R2Shared.framework */; };
+		CA038E4A2521F34E00489729 /* WKWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA038E492521F34E00489729 /* WKWebView.swift */; };
 		CA0B3AC3222EE555006D9363 /* PDFNavigatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0B3AC2222EE555006D9363 /* PDFNavigatorViewController.swift */; };
 		CA1E4F4B240037E6009C4DE3 /* CompletionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1E4F4A240037E6009C4DE3 /* CompletionList.swift */; };
 		CA26EF7E22803FE90011653E /* VisualNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26EF7D22803FE90011653E /* VisualNavigator.swift */; };
@@ -41,6 +42,7 @@
 /* Begin PBXFileReference section */
 		035CE41624F7E2090062EE28 /* SwiftSoup.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftSoup.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03C3CC67222DBD8600A01731 /* R2Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA038E492521F34E00489729 /* WKWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKWebView.swift; sourceTree = "<group>"; };
 		CA0B3AC2222EE555006D9363 /* PDFNavigatorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFNavigatorViewController.swift; sourceTree = "<group>"; };
 		CA1E4F4A240037E6009C4DE3 /* CompletionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionList.swift; sourceTree = "<group>"; };
 		CA26EF7D22803FE90011653E /* VisualNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualNavigator.swift; sourceTree = "<group>"; };
@@ -87,6 +89,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CA038E482521F34300489729 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				CA038E492521F34E00489729 /* WKWebView.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		CA0B3AC1222EE530006D9363 /* PDF */ = {
 			isa = PBXGroup;
 			children = (
@@ -100,6 +110,7 @@
 		CA479DC1226493390053445E /* Toolkit */ = {
 			isa = PBXGroup;
 			children = (
+				CA038E482521F34300489729 /* Extensions */,
 				CA1E4F4A240037E6009C4DE3 /* CompletionList.swift */,
 				CAF1E3F422DF23F400E807EA /* PaginationView.swift */,
 				CAD178B522B3B553004E6812 /* R2NavigatorLocalizedString.swift */,
@@ -304,6 +315,7 @@
 				F3E7D42E1F4EE0FE00DF166D /* CBZNavigatorViewController.swift in Sources */,
 				CA479DC52264AEA20053445E /* UIColor.swift in Sources */,
 				CAD178B622B3B553004E6812 /* R2NavigatorLocalizedString.swift in Sources */,
+				CA038E4A2521F34E00489729 /* WKWebView.swift in Sources */,
 				CAEACA222272EFBD00476340 /* ImageViewController.swift in Sources */,
 				CACE84FB2254BFEE00E19E8B /* EditingAction.swift in Sources */,
 				CAFB017724D48FC2006B074C /* PDFTapGestureController.swift in Sources */,

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -52,7 +52,9 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         /// Authorized actions to be displayed in the selection menu.
         public var editingActions: [EditingAction] = EditingAction.defaultActions
         
-        /// Content insets used to add some vertical margins around reflowable EPUB publications. The insets can be configured for each size class to allow smaller margins on compact screens.
+        /// Content insets used to add some vertical margins around reflowable EPUB publications.
+        /// The insets can be configured for each size class to allow smaller margins on compact
+        /// screens.
         public var contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets] = [
             .compact: (top: 20, bottom: 20),
             .regular: (top: 44, bottom: 44)
@@ -64,6 +66,9 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         /// Number of positions (as in `Publication.positionList`) to preload after the current page.
         public var preloadNextPositionCount = 6
         
+        /// Logs the state changes when true.
+        public var debugState = false
+        
         public init() {}
     }
     
@@ -71,14 +76,102 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         didSet { notifyCurrentLocation() }
     }
     public var userSettings: UserSettings
+
+    public var readingProgression: ReadingProgression {
+        didSet { updateUserSettingStyle() }
+    }
     
+    /// Navigation state.
+    private enum State: Equatable {
+        /// Loading the spreads, for example after changing the user settings or loading the publication.
+        case loading
+        /// Waiting for further navigation instructions.
+        case idle
+        /// Jumping to `pendingLocator`.
+        case jumping(pendingLocator: Locator)
+        /// Turning the page in the given `direction`.
+        case moving(direction: EPUBSpreadView.Direction)
+        
+        mutating func transition(_ event: Event) -> Bool {
+            switch (self, event) {
+            
+            // All events are ignored when loading spreads, except for `loaded` and `load`.
+            case (.loading, .load):
+                return true
+            case (.loading, .loaded):
+                self = .idle
+            case (.loading, _):
+                return false
+
+            case (.idle, .jump(let locator)):
+                self = .jumping(pendingLocator: locator)
+            case (.idle, .move(let direction)):
+                self = .moving(direction: direction)
+
+            case (.jumping, .jumped):
+                self = .idle
+            // Moving or jumping to another locator is not allowed during a pending jump.
+            case (.jumping, .jump),
+                 (.jumping, .move):
+                return false
+                
+            case (.moving, .moved):
+                self = .idle
+            // Moving or jumping to another locator is not allowed during a pending move.
+            case (.moving, .jump),
+                 (.moving, .move):
+                return false
+
+            // Loading the spreads is always possible, because it can be triggered by rotating the
+            // screen. In which case it cancels any on-going state.
+            case (_, .load):
+                self = .loading
+                
+            default:
+                log(.error, "Invalid event \(event) for state \(self)")
+                return false
+            }
+            
+            return true
+        }
+    }
+    
+    /// Navigation event.
+    private enum Event: Equatable {
+        /// Load the spreads, for example after changing the user settings or loading the publication.
+        case load
+        /// The spreads were loaded.
+        case loaded
+        /// Jump to the given locator.
+        case jump(Locator)
+        /// Finished jumping to a locator.
+        case jumped
+        /// Turn the page in the given direction.
+        case move(EPUBSpreadView.Direction)
+        /// Finished turning the page.
+        case moved
+    }
+    
+    /// Current navigation state.
+    private var state: State = .loading {
+        didSet {
+            if (config.debugState) {
+                log(.debug, "* \(state)")
+            }
+            
+            // Disable user interaction while transitioning, to avoid UX issues.
+            switch state {
+            case .loading, .jumping, .moving:
+                paginationView.isUserInteractionEnabled = false
+            case .idle:
+                paginationView.isUserInteractionEnabled = true
+            }
+        }
+    }
+
     private let config: Configuration
     private let publication: Publication
     private let editingActions: EditingActionsController
-
-    public var readingProgression: ReadingProgression {
-        didSet { reloadSpreads() }
-    }
 
     /// Base URL on the resources server to the files in Static/
     /// Used to serve Readium CSS.
@@ -127,6 +220,15 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         paginationView.frame = view.bounds
         paginationView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.addSubview(paginationView)
+        
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
+    }
+    
+    /// Intercepts tap gesture when the web views are not loaded.
+    @objc private func didTapBackground(_ gesture: UITapGestureRecognizer) {
+        guard state == .loading else { return }
+        let point = gesture.location(in: view)
+        delegate?.navigator(self, didTapAt: point)
     }
 
     open override func viewWillDisappear(_ animated: Bool) {
@@ -147,6 +249,17 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         })
     }
 
+    @discardableResult
+    private func on(_ event: Event) -> Bool {
+        assert(Thread.isMainThread, "Raising navigation events must be done from the main thread")
+        
+        if (config.debugState) {
+            log(.debug, "-> on \(event)")
+        }
+        
+        return state.transition(event)
+    }
+    
     /// Mapping between reading order hrefs and the table of contents title.
     private lazy var tableOfContentsTitleByHref: [String: String] = {
         func fulfill(linkList: [Link]) -> [String: String] {
@@ -167,19 +280,19 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         return fulfill(linkList: publication.tableOfContents)
     }()
 
-    /// Goes to the reading order resource at given `index`, and given content location.
-    @discardableResult
-    private func goToReadingOrderIndex(_ index: Int, location: Locator? = nil, animated: Bool = false, completion: @escaping () -> Void = {}) -> Bool {
-        let href = publication.readingOrder[index].href
-        guard let spreadIndex = spreads.firstIndex(withHref: href) else {
+    /// Goes to the next or previous page in the given scroll direction.
+    private func go(to direction: EPUBSpreadView.Direction, animated: Bool, completion completionBlock: @escaping () -> Void) -> Bool {
+        guard on(.move(direction)) else {
             return false
         }
-        return paginationView.goToIndex(spreadIndex, location: PageLocation(location), animated: animated, completion: completion)
-    }
-    
-    /// Goes to the next or previous page in the given scroll direction.
-    private func go(to direction: EPUBSpreadView.Direction, animated: Bool, completion: @escaping () -> Void) -> Bool {
-        if let spreadView = paginationView.currentView as? EPUBSpreadView,
+        
+        let completion = {
+            self.on(.moved)
+            completionBlock()
+        }
+        
+        if
+            let spreadView = paginationView.currentView as? EPUBSpreadView,
             spreadView.go(to: direction, animated: animated, completion: completion)
         {
             return true
@@ -187,37 +300,62 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         
         let isRTL = (readingProgression == .rtl)
         let delta = isRTL ? -1 : 1
-        switch direction {
-        case .left:
-            let location: PageLocation = isRTL ? .start : .end
-            return paginationView.goToIndex(currentSpreadIndex - delta, location: location, animated: animated, completion: completion)
-        case .right:
-            let location: PageLocation = isRTL ? .end : .start
-            return paginationView.goToIndex(currentSpreadIndex + delta, location: location, animated: animated, completion: completion)
+        let moved: Bool = {
+            switch direction {
+            case .left:
+                let location: PageLocation = isRTL ? .start : .end
+                return paginationView.goToIndex(currentSpreadIndex - delta, location: location, animated: animated, completion: completion)
+            case .right:
+                let location: PageLocation = isRTL ? .end : .start
+                return paginationView.goToIndex(currentSpreadIndex + delta, location: location, animated: animated, completion: completion)
+            }
+        }()
+        
+        if !moved {
+            on(.moved)
         }
+        
+        return moved
     }
     
     
     // MARK: - User settings
     
+    private var needsUpdateUserSettings: Bool = false
+    
     public func updateUserSettingStyle() {
         assert(Thread.isMainThread, "User settings must be updated from the main thread")
         
-        guard !paginationView.isEmpty else {
+        guard !needsUpdateUserSettings else {
             return
         }
-        
-        reloadSpreads()
-        
-        let location = currentLocation
-        for (_, view) in paginationView.loadedViews {
-            (view as? EPUBSpreadView)?.applyUserSettingsStyle()
+        needsUpdateUserSettings = true
+
+        func update() {
+            guard
+                state == .idle,
+                !paginationView.isEmpty
+            else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: update)
+                return
+            }
+    
+            reloadSpreads()
+    
+            let location = currentLocation
+            for (_, view) in paginationView.loadedViews {
+                (view as? EPUBSpreadView)?.applyUserSettingsStyle()
+            }
+    
+            // Re-positions the navigator to the location before applying the settings
+            if let location = location {
+                go(to: location)
+            }
+    
+            needsUpdateUserSettings = false
         }
         
-        // Re-positions the navigator to the location before applying the settings
-        if let location = location {
-            go(to: location)
-        }
+        update()
     }
 
     
@@ -233,14 +371,22 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
 
     // Reading order index of the left-most resource in the visible spread.
     private var currentResourceIndex: Int? {
+        guard spreads.indices.contains(currentSpreadIndex) else {
+            return nil
+        }
+        
         return publication.readingOrder.firstIndex(withHREF: spreads[currentSpreadIndex].left.href)
     }
 
     private func reloadSpreads(at locator: Locator? = nil) {
         let isLandscape = (view.bounds.width > view.bounds.height)
         let pageCountPerSpread = EPUBSpread.pageCountPerSpread(for: publication, userSettings: userSettings, isLandscape: isLandscape)
-        guard spreads.first?.pageCount != pageCountPerSpread else {
+        
+        guard
             // Already loaded with the expected amount of spreads.
+            spreads.first?.pageCount != pageCountPerSpread,
+            on(.load)
+        else {
             return
         }
 
@@ -255,13 +401,20 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
             }
         }()
         
-        paginationView.reloadAtIndex(initialIndex, location: PageLocation(locator), pageCount: spreads.count, readingProgression: readingProgression)
+        paginationView.reloadAtIndex(initialIndex, location: PageLocation(locator), pageCount: spreads.count, readingProgression: readingProgression) {
+            self.on(.loaded)
+        }
     }
 
     
     // MARK: - Navigator
     
     public var currentLocation: Locator? {
+        // Returns any pending locator to prevent returning invalid locations while loading it.
+        if case let .jumping(pendingLocator) = state {
+            return pendingLocator
+        }
+        
         guard let spreadView = paginationView.currentView as? EPUBSpreadView else {
             return nil
         }
@@ -294,22 +447,49 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
     /// Used to avoid sending twice the same location.
     private var notifiedCurrentLocation: Locator?
     
+    private var needsNotifyCurrentLocation = false
+    
     fileprivate func notifyCurrentLocation() {
-        guard let delegate = delegate,
-            let location = currentLocation,
-            location != notifiedCurrentLocation else
-        {
+        guard !needsNotifyCurrentLocation else {
             return
         }
-        notifiedCurrentLocation = location
-        delegate.navigator(self, locationDidChange: location)
+        needsNotifyCurrentLocation = true
+        
+        func notify() {
+            // If we're not in a `idle` state, we postpone the notification.
+            guard state == .idle else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: notify)
+                return
+            }
+            needsNotifyCurrentLocation = false
+            
+            guard
+                let delegate = delegate,
+                let location = currentLocation,
+                location != notifiedCurrentLocation
+            else {
+                return
+            }
+    
+            notifiedCurrentLocation = location
+            delegate.navigator(self, locationDidChange: location)
+        }
+        
+        notify()
     }
     
     public func go(to locator: Locator, animated: Bool, completion: @escaping () -> Void) -> Bool {
-        guard let spreadIndex = spreads.firstIndex(withHref: locator.href) else {
+        guard
+            let spreadIndex = spreads.firstIndex(withHref: locator.href),
+            on(.jump(locator))
+        else {
             return false
         }
-        return paginationView.goToIndex(spreadIndex, location: .locator(locator), animated: animated, completion: completion)
+        
+        return paginationView.goToIndex(spreadIndex, location: .locator(locator), animated: animated) {
+            self.on(.jumped)
+            completion()
+        }
     }
     
     public func go(to link: Link, animated: Bool, completion: @escaping () -> Void) -> Bool {
@@ -344,15 +524,10 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
 
 extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
     
-    func spreadViewWillAnimate(_ spreadView: EPUBSpreadView) {
-        paginationView.isUserInteractionEnabled = false
-    }
-    
-    func spreadViewDidAnimate(_ spreadView: EPUBSpreadView) {
-        paginationView.isUserInteractionEnabled = true
-    }
-    
     func spreadView(_ spreadView: EPUBSpreadView, didTapAt point: CGPoint) {
+        // We allow taps in any state, because we should always be able to toggle the navigation bar,
+        // even while a locator is pending.
+        
         let point = view.convert(point, from: spreadView)
         delegate?.navigator(self, didTapAt: point)
         // FIXME: Deprecated, to be removed at some point.
@@ -373,6 +548,8 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
     }
     
     func spreadView(_ spreadView: EPUBSpreadView, didTapOnExternalURL url: URL) {
+        guard state == .idle else { return }
+        
         delegate?.navigator(self, presentExternalURL: url)
     }
     
@@ -574,18 +751,11 @@ extension EPUBNavigatorViewController {
     @available(*, deprecated, message: "Use `publication.tableOfContents` instead")
     public func getTableOfContents() -> [Link] { return publication.tableOfContents }
 
-    @available(*, deprecated, renamed: "go(to:)")
-    public func displayReadingOrderItem(at index: Int) {
-        goToReadingOrderIndex(index)
-    }
+    @available(*, unavailable, renamed: "go(to:)")
+    public func displayReadingOrderItem(at index: Int) {}
     
-    @available(*, deprecated, renamed: "go(to:)")
-    public func displayReadingOrderItem(at index: Int, progression: Double) {
-        let locator = Locator(link: publication.readingOrder[index]).copy(
-            locations: { $0.progression = progression }
-        )
-        goToReadingOrderIndex(index, location: locator)
-    }
+    @available(*, unavailable, renamed: "go(to:)")
+    public func displayReadingOrderItem(at index: Int, progression: Double) {}
     
     @available(*, deprecated, renamed: "go(to:)")
     public func displayReadingOrderItem(with href: String) -> Int? {

--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -16,11 +16,6 @@ import SwiftSoup
 
 protocol EPUBSpreadViewDelegate: class {
     
-    /// Called before the spread view animates its content (eg. page change in reflowable).
-    func spreadViewWillAnimate(_ spreadView: EPUBSpreadView)
-    /// Called after the spread view animates its content (eg. page change in reflowable).
-    func spreadViewDidAnimate(_ spreadView: EPUBSpreadView)
-    
     /// Called when the user tapped on the spread contents.
     func spreadView(_ spreadView: EPUBSpreadView, didTapAt point: CGPoint)
     
@@ -291,9 +286,16 @@ class EPUBSpreadView: UIView, Loggable {
         completion?()
     }
     
-    enum Direction {
+    enum Direction: CustomStringConvertible {
         case left
         case right
+        
+        var description: String {
+            switch self {
+            case .left: return "left"
+            case .right: return "right"
+            }
+        }
     }
     
     func go(to direction: Direction, animated: Bool = false, completion: @escaping () -> Void = {}) -> Bool {
@@ -453,21 +455,12 @@ extension EPUBSpreadView: UIScrollViewDelegate {
     
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         scrollView.isUserInteractionEnabled = true
-        delegate?.spreadViewDidAnimate(self)
     }
     
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         webView.dismissUserSelection()
     }
-    
-    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        delegate?.spreadViewDidAnimate(self)
-    }
-    
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        delegate?.spreadViewDidAnimate(self)
-    }
-    
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // Do not remove, overriden in subclasses.
     }

--- a/r2-navigator-swift/Toolkit/Extensions/WKWebView.swift
+++ b/r2-navigator-swift/Toolkit/Extensions/WKWebView.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright 2020 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import WebKit
+
+extension WKWebView {
+    
+    /// Removes the native double-tap gesture from the `WKWebView`.
+    ///
+    /// This needs to be called every time the web view navigates, in
+    /// `WKNavigationDelegate.webView(_:didFinish:)`
+    ///
+    /// Inspired by https://stackoverflow.com/a/42939172/1474476
+    func removeDoubleTapGestureRecognizer() {
+        for subview in scrollView.subviews {
+            for recognizer in subview.gestureRecognizers ?? [] {
+                if
+                    let tapRecognizer = recognizer as? UITapGestureRecognizer,
+                    tapRecognizer.numberOfTapsRequired == 2,
+                    tapRecognizer.numberOfTouchesRequired == 1
+                {
+                    subview.removeGestureRecognizer(tapRecognizer)
+                }
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
* Introduce a state machine in the EPUB navigator (Fix https://github.com/readium/r2-navigator-swift/issues/102)
* Prevent breaking initial location when calling `updateUserSettings` too soon (Fix https://github.com/readium/r2-navigator-swift/issues/101)
* Fix weird scrolling behavior when tapping two fast on the edges to turn pages (Fix https://github.com/readium/r2-navigator-swift/issues/141)
* Don't send intermediate incorrect locators when loading a pending locator