### PR TITLE
Deprecate ContentLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with caution.
+**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
+*caution.
 
 ## [Unreleased]
+
+### Fixed
+
+* EPUBs declaring multiple languages were laid out from right to left if the first language had an RTL reading
+progression. Now if no reading progression is set, the `effectiveReadingProgression` will be LTR.
 
 
 ## [2.0.0-alpha.2]

--- a/r2-navigator-swift/CBZ/CBZNavigatorViewController.swift
+++ b/r2-navigator-swift/CBZ/CBZNavigatorViewController.swift
@@ -129,7 +129,7 @@ open class CBZNavigatorViewController: UIViewController, VisualNavigator, Loggab
     // MARK: - Navigator
     
     public var readingProgression: ReadingProgression {
-        return publication.contentLayout.readingProgression
+        publication.metadata.effectiveReadingProgression
     }
 
     public var currentLocation: Locator? {

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -184,7 +184,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         self.editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights)
         self.userSettings = UserSettings()
         publication.userProperties.properties = self.userSettings.userProperties.properties
-        self.readingProgression = publication.contentLayout.readingProgression
+        self.readingProgression = publication.metadata.effectiveReadingProgression
         self.config = config
         self.paginationView = PaginationView(frame: .zero, preloadPreviousPositionCount: config.preloadPreviousPositionCount, preloadNextPositionCount: config.preloadNextPositionCount)
 
@@ -634,7 +634,6 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
             publication: publication,
             spread: spread,
             resourcesURL: resourcesURL,
-            contentLayout: publication.contentLayout,
             readingProgression: readingProgression,
             userSettings: userSettings,
             animatedLoad: false,  // FIXME: custom animated

--- a/r2-navigator-swift/EPUB/EPUBSpread.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpread.swift
@@ -213,7 +213,7 @@ struct EPUBSpread: Loggable {
         /// Two resources are consecutive if their position hint (Properties.Page) are paired according to the reading progression.
         func areConsecutive(_ first: Link, _ second: Link) -> Bool {
             // Here we use the default publication reading progression instead of the custom one provided, otherwise the page position hints might be wrong, and we could end up with only one-page spreads.
-            switch publication.contentLayout.readingProgression {
+            switch publication.metadata.effectiveReadingProgression {
             case .ltr, .ttb, .auto:
                 let firstPosition = first.properties.page ?? .left
                 let secondPosition = second.properties.page ?? .right

--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -42,7 +42,6 @@ class EPUBSpreadView: UIView, Loggable {
     let resourcesURL: URL?
     let webView: WebView
 
-    let contentLayout: ContentLayout
     let readingProgression: ReadingProgression
     let userSettings: UserSettings
     let editingActions: EditingActionsController
@@ -65,11 +64,10 @@ class EPUBSpreadView: UIView, Loggable {
 
     private(set) var spreadLoaded = false
 
-    required init(publication: Publication, spread: EPUBSpread, resourcesURL: URL?, contentLayout: ContentLayout, readingProgression: ReadingProgression, userSettings: UserSettings, animatedLoad: Bool = false, editingActions: EditingActionsController, contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets]) {
+    required init(publication: Publication, spread: EPUBSpread, resourcesURL: URL?, readingProgression: ReadingProgression, userSettings: UserSettings, animatedLoad: Bool = false, editingActions: EditingActionsController, contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets]) {
         self.publication = publication
         self.spread = spread
         self.resourcesURL = resourcesURL
-        self.contentLayout = contentLayout
         self.readingProgression = readingProgression
         self.userSettings = userSettings
         self.editingActions = editingActions

--- a/r2-navigator-swift/PDF/PDFNavigatorViewController.swift
+++ b/r2-navigator-swift/PDF/PDFNavigatorViewController.swift
@@ -260,7 +260,7 @@ open class PDFNavigatorViewController: UIViewController, VisualNavigator, Loggab
     // MARK: - Navigator
 
     public var readingProgression: ReadingProgression {
-        return publication.contentLayout.readingProgression
+        publication.metadata.effectiveReadingProgression
     }
     
     public var currentLocation: Locator? {


### PR DESCRIPTION
Fix #146 

* EPUBs declaring multiple languages were laid out from right to left if the first language had an RTL reading
progression. Now if no reading progression is set, the `effectiveReadingProgression` will be LTR.
