### PR TITLE
Disable WKWebView cache when reading a publication

### DIFF
--- a/r2-navigator-swift/Toolkit/WebView.swift
+++ b/r2-navigator-swift/Toolkit/WebView.swift
@@ -1,12 +1,7 @@
 //
-//  WebView.swift
-//  r2-navigator-swift
-//
-//  Created by Mickaël Menu on 20.05.19.
-//
 //  Copyright 2019 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
@@ -20,7 +15,14 @@ final class WebView: WKWebView {
 
     init(editingActions: EditingActionsController) {
         self.editingActions = editingActions
-        super.init(frame: .zero, configuration: .init())
+
+        let config = WKWebViewConfiguration()
+
+        // This is equivalent to a private browsing session. We need this to prevent caching publication resources,
+        // which could pose a security threat for protected content.
+        config.websiteDataStore = .nonPersistent()
+
+        super.init(frame: .zero, configuration: config)
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
HTTP caching poses a security threat for protected content because the resources are stored on the disk as plain text.

This PR disables on-disk caching for the `WKWebView` used with the EPUB navigator, making it equivalent to a private browsing session. A side-effect is that cookies and local storages are not persisted. I'm not sure of the impact on publications but they are not officially supported by Readium yet.

Performance impact should be minimal since HTML Web Publications are not widespread, but we might need a finer strategy later on. For example, by relying on the [Content Protection Service](https://readium.org/architecture/proposals/006-content-protection) to determine if caching must be disabled.