### PR TITLE
Fix EPUB navigator set-up issues

### DIFF
--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -156,7 +156,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
     private var state: State = .loading {
         didSet {
             if (config.debugState) {
-                log(.debug, "* \(state)")
+                log(.debug, "* transitioned to \(state)")
             }
             
             // Disable user interaction while transitioning, to avoid UX issues.

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -330,7 +330,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
     
     private lazy var _updateUserSettingsStyle = execute(
         when: { [weak self] in self?.state == .idle && self?.paginationView.isEmpty == false },
-        pollingInterval: 0.1
+        pollingInterval: userSettingsStylePollingInterval
     ) { [weak self] in
         guard let self = self else { return }
 
@@ -346,6 +346,28 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
             self.go(to: location)
         }
     }
+
+    /// Polling interval to refresh user settings styles
+    ///
+    /// The polling that we perform to update the styles copes with the fact
+    /// that we cannot know when the web view has finished layout. From
+    /// empirical observations it appears that the completion speed of that
+    /// work is vastly dependent on the version of the OS, probably in
+    /// conjunction with performance-related variables such as the CPU load,
+    /// age of the device/battery, memory pressure.
+    ///
+    /// Having too small a value here may cause race conditions inside the
+    /// navigator code, causing for example failure to open the navigator to
+    /// the intended initial location.
+    private let userSettingsStylePollingInterval: TimeInterval = {
+        if #available(iOS 14, *) {
+            return 0.1
+        } else if #available(iOS 13, *) {
+            return 0.5
+        } else {
+            return 2.0
+        }
+    }()
 
     
     // MARK: - Pagination and spreads

--- a/r2-navigator-swift/EPUB/EPUBReflowableSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBReflowableSpreadView.swift
@@ -145,7 +145,8 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
     }
 
     override func spreadDidLoad() {
-        // FIXME: We need to give the CSS and webview time to layout correctly. 0.2 seconds seems like a good value for it to work on an iPhone 5s. Look into solving this better
+        // FIXME: Better solution for delaying scrolling to pending location
+        // This delay is used to wait for the web view pagination to settle and give the CSS and webview time to layout correctly before attempting to scroll to the target progression, otherwise we might end up at the wrong spot. 0.2 seconds seems like a good value for it to work on an iPhone 5s.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             self.go(to: self.pendingLocation) {
                 self.showSpread()
@@ -178,6 +179,7 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
         
         scrollView.setContentOffset(newOffset, animated: animated)
         
+        // This delay is only used when turning pages in a single resource if the page turn is animated. The delay is roughly the length of the animation.
         // FIXME: completion should be implemented using scroll view delegates
         DispatchQueue.main.asyncAfter(
             deadline: .now() + (animated ? 0.3 : 0),

--- a/r2-navigator-swift/Toolkit/PaginationView.swift
+++ b/r2-navigator-swift/Toolkit/PaginationView.swift
@@ -26,7 +26,7 @@ enum PageLocation {
         switch self {
         case .start:
             return true
-        case .locator(let locator) where locator.locations.progression ?? 0 > 0:
+        case .locator(let locator) where locator.locations.progression ?? 0 == 0:
             return true
         default:
             return false


### PR DESCRIPTION
Address the behavior described in issue #153:

- Fix `PageLocation::isStart` computed variable for `.locator` case.
- Add comments from the discussion of issue #153 to further explain the reasoning behind some of the hard-coded delays used to cope with the web view layout process.
- Customize ad-hoc polling interval for updating user settings styles by iOS version.

With regard to the last point, I'm not very proud of this solution but it's the only one that seemed reliable enough without changing too much of how the EPUB navigator currently works. These values derive from observations debugging issue #153 on physical devices and they try to be pretty generous because there are variable outside of our control that these delays need to deal with.

One option I considered is to delegate the polling interval value to the caller, via an additional `EPUBNavigatorViewController::Configuration` parameter. I'm not sure that's better though. It will expose an implementation detail to the clients, putting the onus on them to figure out what's the correct polling interval to use, for something they are not (and should not be) familiar with. Really this is the responsibility of the navigator and the QA of this should not fall on clients, IMO.

Speaking of QA, I have tested this fix on all iOS simulators down to iOS 10.3.1. For physical devices, I was  helped by the SimplyE team (@jbdalton, @ErnestFan, Sultan Mahmud and @antlong which I thank dearly!) and we tested this fix on the following iOS versions and devices:

iOS 12.5.1: iPhone 6, iPad mini 2 (Model A1490)
iOS 13.6: iPhone Xr
iOS 13.7: iPhone 7
iOS 14.0: iPhone 7
iOS 14.3: iPhone X
iOS 14.4: iPhone X, iPhone XS, iPhone 11

