### PR TITLE
Proof of concept to replace the HTTP server with WKURLSchemeHandler

### DIFF
--- a/r2-navigator-swift.xcodeproj/project.pbxproj
+++ b/r2-navigator-swift.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CAAABA9B24D695E5004A4466 /* TargetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAABA9A24D695E5004A4466 /* TargetAction.swift */; };
 		CAB9086B22492D4C00711C3F /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB9086A22492D4C00711C3F /* Navigator.swift */; };
 		CAC2A6D72292E4BA000AA2A7 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC2A6D62292E4BA000AA2A7 /* WebView.swift */; };
+		CAC6C98A261DB0B900EAF2BD /* WebViewResourceHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC6C989261DB0B900EAF2BD /* WebViewResourceHandler.swift */; };
 		CACE84F82254BE5F00E19E8B /* PDFDocumentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACE84F72254BE5F00E19E8B /* PDFDocumentView.swift */; };
 		CACE84FB2254BFEE00E19E8B /* EditingAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACE84FA2254BFEE00E19E8B /* EditingAction.swift */; };
 		CACE851F225CDE3400E19E8B /* EPUBFixedSpreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACE851E225CDE3300E19E8B /* EPUBFixedSpreadView.swift */; };
@@ -63,6 +64,7 @@
 		CAAABA9A24D695E5004A4466 /* TargetAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetAction.swift; sourceTree = "<group>"; };
 		CAB9086A22492D4C00711C3F /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		CAC2A6D62292E4BA000AA2A7 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		CAC6C989261DB0B900EAF2BD /* WebViewResourceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewResourceHandler.swift; sourceTree = "<group>"; };
 		CACE84F72254BE5F00E19E8B /* PDFDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentView.swift; sourceTree = "<group>"; };
 		CACE84FA2254BFEE00E19E8B /* EditingAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingAction.swift; sourceTree = "<group>"; };
 		CACE851E225CDE3300E19E8B /* EPUBFixedSpreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFixedSpreadView.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				CA479DC2226493570053445E /* UIView.swift */,
 				CA479DC42264AEA20053445E /* UIColor.swift */,
 				CAC2A6D62292E4BA000AA2A7 /* WebView.swift */,
+				CAC6C989261DB0B900EAF2BD /* WebViewResourceHandler.swift */,
 			);
 			path = Toolkit;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				CACE84F82254BE5F00E19E8B /* PDFDocumentView.swift in Sources */,
 				CAC2A6D72292E4BA000AA2A7 /* WebView.swift in Sources */,
 				CA1E4F4B240037E6009C4DE3 /* CompletionList.swift in Sources */,
+				CAC6C98A261DB0B900EAF2BD /* WebViewResourceHandler.swift in Sources */,
 				CACE8521225CDFB000E19E8B /* EPUBReflowableSpreadView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/r2-navigator-swift/EPUB/EPUBReflowableSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBReflowableSpreadView.swift
@@ -57,7 +57,8 @@ final class EPUBReflowableSpreadView: EPUBSpreadView {
             return
         }
         let link = spread.leading
-        guard let url = link.url(relativeTo: publication.baseURL) else {
+        guard let url = URL(string: "readium-pub://" + link.href) else {
+//        guard let url = link.url(relativeTo: publication.baseURL) else {
             log(.error, "Can't get URL for link \(link.href)")
             return
         }

--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -64,7 +64,16 @@ class EPUBSpreadView: UIView, Loggable {
 
     private(set) var spreadLoaded = false
 
-    required init(publication: Publication, spread: EPUBSpread, resourcesURL: URL?, readingProgression: ReadingProgression, userSettings: UserSettings, animatedLoad: Bool = false, editingActions: EditingActionsController, contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets]) {
+    required init(
+        publication: Publication,
+        spread: EPUBSpread,
+        resourcesURL: URL?,
+        readingProgression: ReadingProgression,
+        userSettings: UserSettings,
+        animatedLoad: Bool = false,
+        editingActions: EditingActionsController,
+        contentInset: [UIUserInterfaceSizeClass: EPUBContentInsets]
+    ) {
         self.publication = publication
         self.spread = spread
         self.resourcesURL = resourcesURL
@@ -72,8 +81,16 @@ class EPUBSpreadView: UIView, Loggable {
         self.userSettings = userSettings
         self.editingActions = editingActions
         self.animatedLoad = animatedLoad
-        self.webView = WebView(editingActions: editingActions)
         self.contentInset = contentInset
+        if #available(iOS 11.0, *) {
+            let scheme = "readium-pub"
+            self.webView = WebView(
+                editingActions: editingActions,
+                schemeHandler: (scheme: scheme, handler: WebViewResourceHandler(scheme: scheme, publication: publication))
+            )
+        } else {
+            self.webView = WebView(editingActions: editingActions)
+        }
 
         super.init(frame: .zero)
         

--- a/r2-navigator-swift/Toolkit/WebView.swift
+++ b/r2-navigator-swift/Toolkit/WebView.swift
@@ -15,14 +15,21 @@ import WebKit
 /// A custom web view which:
 ///  - Forwards copy: menu action to an EditingActionsController.
 final class WebView: WKWebView {
-    
+
     private let editingActions: EditingActionsController
 
-    init(editingActions: EditingActionsController) {
+    init(editingActions: EditingActionsController, configuration: WKWebViewConfiguration = .init()) {
         self.editingActions = editingActions
-        super.init(frame: .zero, configuration: .init())
+        super.init(frame: .zero, configuration: configuration)
     }
-    
+
+    @available(iOS 11.0, *)
+    convenience init(editingActions: EditingActionsController, schemeHandler: (scheme: String, handler: WKURLSchemeHandler)) {
+        let configuration = WKWebViewConfiguration()
+        configuration.setURLSchemeHandler(schemeHandler.handler, forURLScheme: schemeHandler.scheme)
+        self.init(editingActions: editingActions, configuration: configuration)
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/r2-navigator-swift/Toolkit/WebViewResourceHandler.swift
+++ b/r2-navigator-swift/Toolkit/WebViewResourceHandler.swift
@@ -1,0 +1,129 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import R2Shared
+import WebKit
+
+@available(iOS 11.0, *)
+final class WebViewResourceHandler: NSObject, WKURLSchemeHandler, Loggable {
+
+    enum HandlerError: Error {
+        case noURLProvided
+        case unsupportedScheme(String?)
+        case taskNotStarted(WKURLSchemeTask)
+    }
+
+    private let scheme: String
+    private let publication: Publication
+    private var tasks: [ObjectIdentifier: Task] = [:]
+
+    init(scheme: String, publication: Publication) {
+        self.scheme = scheme
+        self.publication = publication
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(HandlerError.noURLProvided)
+            return
+        }
+        guard url.scheme == scheme else {
+            urlSchemeTask.didFailWithError(HandlerError.unsupportedScheme(url.scheme))
+            return
+        }
+
+        let href = url.absoluteString.removingPrefix(scheme + "://")
+        let resource = publication.get(href)
+        let task = Task(url: url, task: urlSchemeTask, resource: resource)
+        tasks[ObjectIdentifier(urlSchemeTask)] = task
+        task.start()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        guard let task = tasks[ObjectIdentifier(urlSchemeTask)] else {
+            urlSchemeTask.didFailWithError(HandlerError.taskNotStarted(urlSchemeTask))
+            return
+        }
+
+        task.cancel()
+    }
+
+    private final class Task {
+        private let url: URL
+        private let task: WKURLSchemeTask
+        private let resource: Resource
+        private var isCancelled = false
+        private let isCancelledQueue = DispatchQueue(label: "org.readium.r2-navigator-swift.WebViewResourceHandler.Task")
+
+        init(url: URL, task: WKURLSchemeTask, resource: Resource) {
+            self.url = url
+            self.task = task
+            self.resource = resource
+        }
+
+        func start() {
+            DispatchQueue.global(qos: .userInitiated).async {
+                let href = self.resource.link.href
+                do {
+                    log(.info, "Will serve \(href), headers: \(self.task.request.allHTTPHeaderFields ?? [:])")
+                    let length = try self.resource.length.get()
+                    let response = URLResponse(
+                        url: self.url,
+                        mimeType: self.resource.link.type,
+                        expectedContentLength: Int(length),
+                        textEncodingName: nil
+                    )
+                    self.ifNotCancelled {
+                        self.task.didReceive(response)
+                    }
+
+                    var available = length
+                    var offset: UInt64 = 0
+                    var data: Data = Data()
+                    repeat {
+                        let upperBound = offset + min(available, 32 * 1024)
+                        data = try self.resource.read(range: offset..<upperBound).get()
+
+                        offset += UInt64(data.count)
+                        available -= UInt64(data.count)
+
+                        self.ifNotCancelled {
+                            self.task.didReceive(data)
+                        }
+                    } while available > 0 && !self.isCancelled
+
+                    self.ifNotCancelled {
+                        self.task.didFinish()
+                    }
+
+                } catch {
+                    log(.error, "Failed to serve \(href): \(error.localizedDescription)")
+                    self.ifNotCancelled {
+                        self.task.didFailWithError(error)
+                    }
+                }
+
+                self.resource.close()
+            }
+        }
+
+        func cancel() {
+            ifNotCancelled {
+                isCancelled = true
+            }
+        }
+
+        func ifNotCancelled(callback: () -> Void) {
+            isCancelledQueue.sync {
+                if !isCancelled {
+                    callback()
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
A first stab at https://github.com/readium/r2-navigator-swift/issues/148

There are a few issues to address.

#### Cancelled `WKURLSchemeTask`

The scheme handler is called on the main thread, so we **must** spawn a background task to read the resource and notify back the `WKURLSchemeTask`. However, if we received a cancellation notification for this task, any new call to `WKURLSchemeTask` crashes the app (low-level exception). But guarding the access to the `isCancelled` property with a serialized queue creates some random deadlocks.

#### Byte range requests

We don't get any byte range information, however the `WKURLSchemeTask` is cancelled before loading the full video content when first loading the page. We can also serve the video progressively so there's no need to load everything in memory at once, however I didn't find any way to start streaming from a particular offset. Need some more testing with large videos to see if random access would work fine.

According to [this bug report](https://bugs.webkit.org/show_bug.cgi?id=203302) on Mac we get byte range info but not on iOS. [This Twitter thread](https://twitter.com/Callionica/status/1255906555599425537) provides more context.