### PR TITLE
Fix receiving navigator(_:setupUserScripts:) for the first web view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
 *caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Deprecated
+
+* Removed `navigator(_:userContentController:didReceive:)` which is actually not needed since you can provide your own `WKScriptMessageHandler` to `WKUserContentController`.
+
+### Fixed
+
+* Fixed receiving `EPUBNavigatorDelegate.navigator(_:setupUserScripts:)` for the first web view.
+
 
 ## [2.0.0-beta.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* New `EPUBNavigatorViewController.evaluateJavaScript()` API to run a JavaScript on the currently visible HTML resource.
+
 ### Deprecated
 
 * Removed `navigator(_:userContentController:didReceive:)` which is actually not needed since you can provide your own `WKScriptMessageHandler` to `WKUserContentController`.

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -21,7 +21,6 @@ public protocol EPUBNavigatorDelegate: VisualNavigatorDelegate {
     // MARK: - WebView Customization
 
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController)
-    func navigator(_ navigator: EPUBNavigatorViewController, userContentController: WKUserContentController, didReceive message: WKScriptMessage)
 
     // MARK: - Deprecated
     
@@ -41,7 +40,6 @@ public protocol EPUBNavigatorDelegate: VisualNavigatorDelegate {
 public extension EPUBNavigatorDelegate {
 
     func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController) {}
-    func navigator(_ navigator: EPUBNavigatorViewController, userContentController: WKUserContentController, didReceive message: WKScriptMessage) {}
 
     func middleTapHandler() {}
     func willExitPublication(documentIndex: Int, progression: Double?) {}
@@ -179,6 +177,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
 
     private let config: Configuration
     private let publication: Publication
+    private let initialLocation: Locator?
     private let editingActions: EditingActionsController
 
     /// Base URL on the resources server to the files in Static/
@@ -189,6 +188,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         assert(!publication.isRestricted, "The provided publication is restricted. Check that any DRM was properly unlocked using a Content Protection.")
         
         self.publication = publication
+        self.initialLocation = initialLocation
         self.editingActions = EditingActionsController(actions: config.editingActions, rights: publication.rights)
         self.userSettings = UserSettings()
         publication.userProperties.properties = self.userSettings.userProperties.properties
@@ -215,7 +215,6 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         
         self.editingActions.delegate = self
         self.paginationView.delegate = self
-        reloadSpreads(at: initialLocation)
     }
 
     @available(*, unavailable)
@@ -232,6 +231,8 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Logga
         view.addSubview(paginationView)
         
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
+
+        reloadSpreads(at: initialLocation)
     }
     
     /// Intercepts tap gesture when the web views are not loaded.
@@ -641,10 +642,6 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
     
     func spreadView(_ spreadView: EPUBSpreadView, present viewController: UIViewController) {
         present(viewController, animated: true)
-    }
-
-    func spreadView(_ spreadView: EPUBSpreadView, userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        delegate?.navigator(self, userContentController: userContentController, didReceive: message)
     }
 
 }

--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -31,9 +31,6 @@ protocol EPUBSpreadViewDelegate: class {
     /// Called when the spread view needs to present a view controller.
     func spreadView(_ spreadView: EPUBSpreadView, present viewController: UIViewController)
 
-    /// Called when the spread view receives an unknown JavaScript message.
-    func spreadView(_ spreadView: EPUBSpreadView, userContentController: WKUserContentController, didReceive message: WKScriptMessage)
-    
 }
 
 class EPUBSpreadView: UIView, Loggable, PageView {
@@ -398,11 +395,10 @@ extension EPUBSpreadView: WKScriptMessageHandler {
 
     /// Handles incoming calls from JS.
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        if let handler = JSMessages[message.name]  {
-            handler(message.body)
-        } else {
-            delegate?.spreadView(self, userContentController: userContentController, didReceive: message)
+        guard let handler = JSMessages[message.name] else {
+            return
         }
+        handler(message.body)
     }
 
 }


### PR DESCRIPTION
### Added

* New `EPUBNavigatorViewController.evaluateJavaScript()` API to run a JavaScript on the currently visible HTML resource.

### Deprecated

* Removed `navigator(_:userContentController:didReceive:)` which is actually not needed since you can provide your own `WKScriptMessageHandler` to `WKUserContentController`.

### Fixed

* Fixed receiving `EPUBNavigatorDelegate.navigator(_:setupUserScripts:)` for the first web view.

(cc @cbaltzer)


Example of use:

```swift
extension EPUBViewController: EPUBNavigatorDelegate {

    func navigator(_ navigator: EPUBNavigatorViewController, setupUserScripts userContentController: WKUserContentController) {
        userContentController.add(self, name: "testing")
        userContentController.addUserScript(WKUserScript(source: "webkit.messageHandlers.testing.postMessage(window.location.href)", injectionTime: .atDocumentEnd, forMainFrameOnly: false))
    }

}

extension EPUBViewController: WKScriptMessageHandler {
    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
        print("Received \(message.name): \(message.body)")
    }
}
```