### PR TITLE
Go to a Locator using its text context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-**Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
+**Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with
 *caution.
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 **Warning:** Features marked as *experimental* may change or be removed in a future release without notice. Use with
 *caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Added
+
+* The EPUB navigator is now able to navigate to a `Locator` using its `text` context. This is useful for search results or highlights missing precise locations.
+
 
 ## [2.0.0-beta.2]
 

--- a/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
+++ b/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
@@ -80,7 +80,7 @@ var readium = (function() {
     function scrollToId(id) {
         var element = document.getElementById(id);
         if (!element) {
-            return;
+            return false;
         }
         element.scrollIntoView();
         
@@ -90,6 +90,7 @@ var readium = (function() {
             // Adds half a page to make sure we don't snap to the previous page.
             document.scrollingElement.scrollLeft = snapOffset(currentOffset + (pageWidth / 2));
         }
+        return true;
     }
 
     // Position must be in the range [0 - 1], 0-100%.
@@ -110,6 +111,101 @@ var readium = (function() {
             var offset = documentWidth * position * factor;
             document.scrollingElement.scrollLeft = snapOffset(offset);
         }
+    }
+
+    // Scrolls to the first occurrence of the given text snippet.
+    //
+    // The expected text argument is a Locator Text object, as defined here:
+    // https://readium.org/architecture/models/locators/
+    function scrollToText(text) {
+        // Wrapper around a browser Selection object.
+        function Selection(selection) {
+            this.selection = selection;
+            this.markedRanges = []
+        }
+
+        // Removes all the ranges of the selection.
+        Selection.prototype.clear = function() {
+            this.selection.removeAllRanges();
+        }
+
+        // Saves the current selection ranges, to be restored later with reset().
+        Selection.prototype.mark = function() {
+            this.markedRanges = []
+            for (var i = 0; i < this.selection.rangeCount; i++) {
+                this.markedRanges.push(this.selection.getRangeAt(i));
+            }
+        }
+
+        // Resets the selection with ranges previously saved with mark().
+        Selection.prototype.reset = function() {
+            this.clear();
+            for (var i = 0; i < this.markedRanges.length; i++) {
+                this.selection.addRange(this.markedRanges[i]);
+            }
+        }
+
+        // Returns the text content of the selection.
+        Selection.prototype.toString = function() {
+            return this.selection.toString();
+        }
+
+        // Extends the selection by moving the start and end positions by the given offsets.
+        Selection.prototype.adjust = function(offset, length) {
+            for (var i = 0; i <= Math.abs(offset); i++) {
+                var direction = (offset >= 0 ? "forward" : "backward")
+                this.selection.modify("move", direction, "character");
+            }
+            for (var i = 0; i <= length; i++) {
+                this.selection.modify("extend", "forward", "character");
+            }
+        }
+
+        Selection.prototype.isEmpty = function() {
+            return this.selection.isCollapsed
+        }
+
+        function removeWhitespaces(s) {
+            return s.replace(/\s+/g, "");
+        }
+
+        var highlight = text.highlight;
+        var before  = text.before || "";
+        var after  = text.after || "";
+        var snippet = before + highlight + after;
+        var safeSnippet = removeWhitespaces(snippet);
+
+        if (!highlight || !safeSnippet) {
+            return false;
+        }
+
+        var selection = new Selection(window.getSelection());
+        // We need to reset any selection to begin the search from the start of the resource.
+        selection.clear();
+
+        var found = false;
+        while (window.find(text.highlight, true)) {
+            if (selection.isEmpty()) {
+                break; // Prevents infinite loop in edge cases.
+            }
+
+            // Get the surrounding context to compare to the expected snippet.
+            selection.mark();
+            selection.adjust(-before.length, snippet.length);
+            var safeSelection = removeWhitespaces(selection.toString());
+            selection.reset();
+
+            if (safeSelection !== "" && (safeSnippet.includes(safeSelection) || safeSelection.includes(safeSnippet))) {
+                found = true;
+                break;
+            }
+        }
+
+        // Resets the selection otherwise the last found occurrence will be highlighted.
+        selection.clear();
+
+        snapCurrentPosition();
+        return found;
     }
 
     // Returns false if the page is already at the left-most scroll offset.
@@ -199,6 +295,7 @@ var readium = (function() {
     return {
         'scrollToId': scrollToId,
         'scrollToPosition': scrollToPosition,
+        'scrollToText': scrollToText,
         'scrollLeft': scrollLeft,
         'scrollRight': scrollRight,
         'setProperty': setProperty,

--- a/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
+++ b/r2-navigator-swift/EPUB/Resources/Scripts/utils.js
@@ -165,6 +165,10 @@ var readium = (function() {
             return this.selection.isCollapsed
         }
 
+        Selection.prototype.getFirstRange = function() {
+            return this.selection.getRangeAt(0);
+        }
+
         function removeWhitespaces(s) {
             return s.replace(/\s+/g, "");
         }
@@ -201,11 +205,28 @@ var readium = (function() {
             }
         }
 
+        if (!found || selection.isEmpty()) {
+            return false;
+        }
+
+        // WKWebView doesn't seem to scroll to the selection created by window.find().
+        // See https://bugs.webkit.org/show_bug.cgi?id=163911
+        scrollToRange(selection.getFirstRange())
+
         // Resets the selection otherwise the last found occurrence will be highlighted.
         selection.clear();
 
-        snapCurrentPosition();
-        return found;
+        return true;
+    }
+
+    function scrollToRange(range) {
+        var rect = range.getBoundingClientRect();
+        if (isScrollModeEnabled()) {
+            document.scrollingElement.scrollTop = rect.top + window.scrollY - (window.innerHeight / 2);
+        } else {
+            document.scrollingElement.scrollLeft = rect.left + window.scrollX;
+            snapCurrentPosition();
+        }
     }
 
     // Returns false if the page is already at the left-most scroll offset.


### PR DESCRIPTION
### Added

* The EPUB navigator is now able to navigate to a `Locator` using its `text` context. This is useful for search results or highlights missing precise locations.