### PR TITLE
Add paragraphMargins user setting

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "cezheng/Fuzi" "3.1.3"
 github "dexman/Minizip" "1.4.0"
-github "readium/r2-shared-swift" "f631efdb51ad6cb55fb173b4e80bbb1d1215fa76"
+github "readium/r2-shared-swift" "7c66c3b7eb8711946b4fca4a1cce8f5ae0bc6bfe"
 github "scinfu/SwiftSoup" "2.3.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/readium/r2-shared-swift.git",
         "state": {
           "branch": "develop",
-          "revision": "f631efdb51ad6cb55fb173b4e80bbb1d1215fa76",
+          "revision": "7c66c3b7eb8711946b4fca4a1cce8f5ae0bc6bfe",
           "version": null
         }
       },


### PR DESCRIPTION
Provides a way for client apps to modify paragraph spacing. This is required to address possible VoiceOver bugs in WKWebView, as described in https://github.com/readium/r2-navigator-swift/issues/197.

The paragraphMargins input param is handled a bit differently than others because, as I explained in the code, sometimes we may not want to change the margins at all (hence the optional ivar and param). In my use case this is in relation to VoiceOver, but I can see this being more generic than just VoiceOver issue. This solution I think provides enough flexibility for everyone (to make the new param work like all others, simply pass a value when creating UserSettings). 

Dependent PR: https://github.com/readium/r2-shared-swift/pull/161
