### PR TITLE
Add translate editing action for iOS 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       scheme: ${{ 'r2-navigator-swift' }}
       platform: ${{ 'iOS Simulator' }}
+      device: ${{ 'iPhone 13' }}
 
     steps:
       - name: Checkout
@@ -31,9 +32,7 @@ jobs:
           rm -rf r2-navigator-swift.xcodeproj
       - name: Build
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
           xcodebuild build-for-testing -scheme "$scheme" -destination "platform=$platform,name=$device"
       - name: Test
         run: |
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
           xcodebuild test-without-building -scheme "$scheme" -destination "platform=$platform,name=$device"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 **Warning:** Features marked as *alpha* may change or be removed in a future release without notice. Use with
 *caution.
 
-<!--## [Unreleased]-->
+## [Unreleased]
+
+### Added
+
+* A new `translate` EPUB and PDF editing action is available for iOS 15.
+
 
 ## [2.1.0]
 

--- a/r2-navigator-swift/EditingAction.swift
+++ b/r2-navigator-swift/EditingAction.swift
@@ -17,7 +17,7 @@ public struct EditingAction: Hashable {
 
     /// Default editing actions enabled in the navigator.
     public static var defaultActions: [EditingAction] {
-        [copy, share, lookup]
+        [copy, share, lookup, translate]
     }
 
     /// Copy the text selection.
@@ -25,6 +25,9 @@ public struct EditingAction: Hashable {
 
     /// Look up the text selection in the dictionary.
     public static let lookup = EditingAction(kind: .native("_lookup:"))
+
+    /// Translate the text selection.
+    public static let translate = EditingAction(kind: .native("_translate:"))
 
     /// Share the text selection.
     ///


### PR DESCRIPTION
### Added

* A new `translate` EPUB and PDF editing action is available for iOS 15.

<img width="352" alt="Screenshot 2021-10-21 at 10 48 52" src="https://user-images.githubusercontent.com/58686775/138244055-e973d9ce-a295-4f73-bdf7-e4f0474fa353.png">
